### PR TITLE
make connector more robust when using `dynamic: strict`

### DIFF
--- a/src/main/java/io/aiven/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/aiven/connect/elasticsearch/bulk/BulkProcessor.java
@@ -436,6 +436,7 @@ public class BulkProcessor<R, B> {
 
     private boolean responseContainsMalformedDocError(final BulkResponse bulkRsp) {
         return bulkRsp.getErrorInfo().contains("mapper_parsing_exception")
+            || bulkRsp.getErrorInfo().contains("strict_dynamic_mapping_exception")
             || bulkRsp.getErrorInfo().contains("illegal_argument_exception");
     }
 


### PR DESCRIPTION
At Wowza, we use strict mappings in ElasticSearch and frequently hit the case (particularly in development), that malformed documents crash the connector tasks.  I would like to propose the following change to `BulkProcessor` to make it more robust in the face of mapping errors. I believe that considering documents causing a `strict_dynamic_mapping_exception` to be malformed is a sound way to deal with this error case, and it represents a minimal change to the code that I have tested in a local setup.